### PR TITLE
DO NOT MERGE - Make content parameter Sensitive

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,12 +4,12 @@ $slack_token = Sensitive('this is sensitive')
 
 file {'/test1':
   ensure => present,
-  content => template('sensitive/test1.erb'),
+  content => Sensitive(template('sensitive/test1.erb')),
 }
 
 file {'/test2':
   ensure => present,
-  content => template('sensitive/test2.epp'),
+  content => Sensitive(template('sensitive/test2.epp')),
 }
 
 


### PR DESCRIPTION
Right now Puppet has no ability to customize the redaction value of a string, which would be required to produce a partially redacted diff from a file. This change demonstrates the closest thing we can do today, which is let Puppet know that the entire value of the file is Sensitive. That will protect the file content string in reports, etc.

File diff output on the command line and in logs may be different, special. I don't know if show_diff understands or is able to account for file resources including Sensitive content.